### PR TITLE
Update docker workflow to push to ECR

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -19,19 +19,20 @@ jobs:
       python_versions: >-
         ["3.9"]
 
-  # TODO: re-enable container building when OPERA containers are public
-  # call-version-info-workflow:
-  #   # Docs: https://github.com/ASFHyP3/actions
-  #   uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.0
-  #
-  # call-docker-ghcr-workflow:
-  #   needs: call-version-info-workflow
-  #   # Docs: https://github.com/ASFHyP3/actions
-  #   uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.11.0
-  #   with:
-  #     version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
-  #     release_branch: main
-  #     develop_branch: develop
-  #     user: tools-bot
-  #   secrets:
-  #     USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  call-version-info-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.18.0
+    with:
+      python_version: '3.9'
+
+  call-docker-ecr-workflow:
+    needs: call-version-info-workflow
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.18.0
+    with:
+      version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
+      ecr_registry: 845172464411.dkr.ecr.us-west-2.amazonaws.com
+      aws_region: us-west-2
+      release_branch: main
+      develop_branch: develop
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opera_pge/rtc_s1:2.1.1
+FROM 845172464411.dkr.ecr.us-west-2.amazonaws.com/opera_pge/rtc_s1:2.1.1
 
 # For opencontainers label definitions, see:
 #    https://github.com/opencontainers/image-spec/blob/master/annotations.md
@@ -15,7 +15,8 @@ RUN conda install -c conda-forge -y git
 COPY --chown=rtc_user:rtc_user . /home/rtc_user/hyp3-opera-rtc/
 RUN python -m pip install --no-cache-dir boto3
 RUN python -m pip install --no-cache-dir --no-deps hyp3lib
-RUN python -m pip install --no-cache-dir /home/rtc_user/hyp3-opera-rtc/
+# FIXME: --user probably isn't the right solution here
+RUN python -m pip install --user --no-cache-dir /home/rtc_user/hyp3-opera-rtc/
 
 ENTRYPOINT ["/home/rtc_user/hyp3-opera-rtc/src/hyp3_opera_rtc/etc/entrypoint.sh"]
 CMD ["-h"]


### PR DESCRIPTION
Branched off of `dem`, but point the PR at `develop` to trigger the build workflow.

Ran successfully: https://github.com/ASFHyP3/hyp3-OPERA-RTC/actions/runs/14391522185/job/40359590980?pr=24

Confirmed I can pull the image from the ECR repo.