### PR TITLE
Revert "Update PGE version"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.4]
 
-### Changed
-- Updated OPERA PGE container version to 2.1.3.
-
-## [0.1.4]
-
 ### Added
 - Added functionality to `prep_rtc.py` and `upload_rtc.py` to accept SLCs or co-pol bursts.
 - Add `--num-workers` as `prep_rtc` cli param

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nasa/opera-sds-pge/opera_pge/rtc_s1:2.1.3
+FROM ghcr.io/nasa/opera-sds-pge/opera_pge/rtc_s1:2.1.1
 
 # For opencontainers label definitions, see:
 #    https://github.com/opencontainers/image-spec/blob/master/annotations.md


### PR DESCRIPTION
Reverts ASFHyP3/hyp3-OPERA-RTC#86

Jobs via HyP3 run after this change all fail with this output:

```
Created archive: /home/rtc_user/input_dir/S1A_IW_SLC__1SDV_20230801T152841_20230801T152905_049683_05F96F_0126.zip
Downloaded orbit file: /home/rtc_user/input_dir/S1A_OPER_AUX_POEORB_OPOD_20230821T080724_V20230731T225942_20230802T005942.EOF
Burst database: /home/rtc_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
Downloaded DEM: /home/rtc_user/input_dir/dem.tif
Traceback (most recent call last):
  File "/home/rtc_user/opera/scripts/pge_main.py", line 194, in <module>
    pge_main()
  File "/home/rtc_user/opera/scripts/pge_main.py", line 190, in pge_main
    pge_start(run_config_filename)
  File "/home/rtc_user/opera/scripts/pge_main.py", line 164, in pge_start
    pge.run()
  File "/home/rtc_user/opera/pge/base/base_pge.py", line 806, in run
    self.run_postprocessor(**kwargs)
  File "/home/rtc_user/opera/pge/rtc_s1/rtc_s1_pge.py", line 938, in run_postprocessor
    self._stage_output_files()
  File "/home/rtc_user/opera/pge/rtc_s1/rtc_s1_pge.py", line 858, in _stage_output_files
    self._assign_filename(output_product, self.runconfig.output_product_path)
  File "/home/rtc_user/opera/pge/base/base_pge.py", line 539, in _assign_filename
    final_filename = rename_function(input_filepath)
  File "/home/rtc_user/opera/pge/rtc_s1/rtc_s1_pge.py", line 534, in _rtc_metadata_filename
    rtc_filename = self._rtc_filename(inter_filename)
  File "/home/rtc_user/opera/pge/rtc_s1/rtc_s1_pge.py", line 271, in _rtc_filename
    product_metadata = self._collect_rtc_product_metadata(
  File "/home/rtc_user/opera/pge/rtc_s1/rtc_s1_pge.py", line 757, in _collect_rtc_product_metadata
    output_product_metadata['MeasuredParameters'] = augment_hdf5_measured_parameters(
  File "/home/rtc_user/opera/util/render_jinja2.py", line 335, in augment_hdf5_measured_parameters
    logger.critical("render_jinja2", ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_NOT_FOUND, msg)
  File "/home/rtc_user/opera/util/logger.py", line 412, in critical
    raise RuntimeError(description)
RuntimeError: Measured parameters configuration is needed to extract the measured parameters attributes from the metadata
ERROR conda.cli.main_run:execute(125): `conda run /home/rtc_user/opera/scripts/pge_main.py -f /home/rtc_user/runconfig.yml` failed. (See above for error)
Running preprocessor for RtcS1PreProcessorMixin
Starting SAS execution for RtcS1Executor
Running postprocessor for RtcS1PostProcessorMixin
```

For a complete list of examples, see https://hyp3-test-api.asf.alaska.edu/jobs?user_id=ffwilliams2&job_type=OPERA_RTC_S1&start=2025-07-29T20:30:00Z