### PR TITLE
Revert "Update pge template yml to add new field"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [0.1.5]
-
-### Changed
-- Updated OPERA PGE container version to 2.1.3.
-
 ## [0.1.4]
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nasa/opera-sds-pge/opera_pge/rtc_s1:2.1.3
+FROM ghcr.io/nasa/opera-sds-pge/opera_pge/rtc_s1:2.1.1
 
 # For opencontainers label definitions, see:
 #    https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/src/hyp3_opera_rtc/templates/pge.yml.j2
+++ b/src/hyp3_opera_rtc/templates/pge.yml.j2
@@ -32,7 +32,6 @@ RunConfig:
         ErrorCodeBase: 300000
         SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
         IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
-        IsoMeasuredParameterDescriptions: /home/rtc_user/opera/pge/rtc_s1/templates/rtc_s1_measured_parameters.yaml
         # Date field which designates the point after which the
         # RTC static layer product(s) should be considered valid.
         # This field must be provided for RTC-S1 jobs when static layer


### PR DESCRIPTION
Reverts ASFHyP3/hyp3-OPERA-RTC#89

Roll develop back to 2.1.1; per discussion with the OPERA team v2.1.3 isn't quite ready for prime time, so we'll use v2.1.1 for any historical processing campaign